### PR TITLE
Update packages to build icinga2 on Ubuntu Xenial

### DIFF
--- a/icinga2-ansible-no-ui/defaults/main.yml
+++ b/icinga2-ansible-no-ui/defaults/main.yml
@@ -32,6 +32,3 @@ icinga2_ubuntu_pkg_deps: # apt-get pinned versions
  - { package: "apache2-utils" }
  - { package: "nagios-plugins" }
  - { package: "bsd-mailx" }
-
-icinga2_ubuntu_pkg: # apt-get pinned versions
- - { package: "icinga2={{ icinga2_version }}.trusty" }

--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -7,13 +7,12 @@
            state=present
   register: add_repository_key
   ignore_errors: true
-  failed_when: no
 
 - name: Add Icinga2 apt key (alternative for older systems without SNI).
   shell: "curl -sSL {{ icinga2_key }} | sudo apt-key add -"
   args:
     warn: no
-  when: add_repository_key|failed
+  when: add_repository_key is failed
 
   # Debian packages require additional packages which are provided by the
   # Debian Monitoring Project repository
@@ -22,13 +21,12 @@
            state=present
   register: add_debmon_repository_key
   ignore_errors: true
-  failed_when: no
 
 - name: Add Debmon apt key (alternative for older systems without SNI).
   shell: "curl -sSL {{ icinga2_debmon_key }} | sudo apt-key add -"
   args:
     warn: no
-  when: add_debmon_repository_key|failed
+  when: add_debmon_repository_key is failed
 
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository: repo='{{ item.repo }}'

--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -7,6 +7,7 @@
            state=present
   register: add_repository_key
   ignore_errors: true
+  failed_when: no
 
 - name: Add Icinga2 apt key (alternative for older systems without SNI).
   shell: "curl -sSL {{ icinga2_key }} | sudo apt-key add -"
@@ -21,6 +22,7 @@
            state=present
   register: add_debmon_repository_key
   ignore_errors: true
+  failed_when: no
 
 - name: Add Debmon apt key (alternative for older systems without SNI).
   shell: "curl -sSL {{ icinga2_debmon_key }} | sudo apt-key add -"

--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -5,12 +5,28 @@
 - name: Get Icinga2 Apt Key for Debian OS family
   apt_key: url={{ icinga2_key }}
            state=present
+  register: add_repository_key
+  ignore_errors: true
+
+- name: Add Icinga2 apt key (alternative for older systems without SNI).
+  shell: "curl -sSL {{ icinga2_key }} | sudo apt-key add -"
+  args:
+    warn: no
+  when: add_repository_key|failed
 
   # Debian packages require additional packages which are provided by the
   # Debian Monitoring Project repository
 - name: Get Debmon Apt Key for Debian OS family (Debian)
   apt_key: url={{ icinga2_debmon_key }}
            state=present
+  register: add_debmon_repository_key
+  ignore_errors: true
+
+- name: Add Debmon apt key (alternative for older systems without SNI).
+  shell: "curl -sSL {{ icinga2_debmon_key }} | sudo apt-key add -"
+  args:
+    warn: no
+  when: add_debmon_repository_key|failed
 
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository: repo='{{ item.repo }}'

--- a/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
@@ -2,7 +2,7 @@
 - name: install urllib3
   pip:
     name: urllib3
-    version: 1.22
+    version: 1.23
 - name: install pyasn1
   pip:
     name: pyasn1

--- a/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
@@ -21,12 +21,28 @@
 - name: Get Icinga2 Apt Key for Debian OS family
   apt_key: url={{ icinga2_key }}
            state=present
+  register: add_repository_key
+  ignore_errors: true
+
+- name: Add Icinga2 apt key (alternative for older systems without SNI).
+  shell: "curl -sSL {{ icinga2_key }} | sudo apt-key add -"
+  args:
+    warn: no
+  when: add_repository_key|failed
 
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository: repo='{{ item.repo }}'
                   update_cache=yes
                   state=present
   with_items: '{{ icinga2_deb_repos }}'
+  register: add_debmon_repository_key
+  ignore_errors: true
+
+- name: Add Debmon apt key (alternative for older systems without SNI).
+  shell: "curl -sSL {{ icinga2_debmon_key }} | sudo apt-key add -"
+  args:
+    warn: no
+  when: add_debmon_repository_key|failed
 
 - name: Install Icinga2 Deps on Debian OS family
   apt: pkg={{ item.package }}

--- a/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
@@ -28,7 +28,7 @@
   shell: "curl -sSL {{ icinga2_key }} | sudo apt-key add -"
   args:
     warn: no
-  when: add_repository_key|failed
+  when: add_repository_key is failed
 
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository: repo='{{ item.repo }}'
@@ -42,7 +42,7 @@
   shell: "curl -sSL {{ icinga2_debmon_key }} | sudo apt-key add -"
   args:
     warn: no
-  when: add_debmon_repository_key|failed
+  when: add_debmon_repository_key is failed
 
 - name: Install Icinga2 Deps on Debian OS family
   apt: pkg={{ item.package }}

--- a/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
@@ -1,8 +1,4 @@
 ---
-- name: install urllib3
-  pip:
-    name: urllib3
-    version: 1.23
 - name: install pyasn1
   pip:
     name: pyasn1

--- a/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
@@ -2,15 +2,15 @@
 - name: install urllib3
   pip:
     name: urllib3
-    version: 1.7.1
+    version: 1.22
 - name: install pyasn1
   pip:
     name: pyasn1
-    version: 0.3.7
+    version: 0.4.1
 - name: install pyOpenSSL
   pip:
     name: pyOpenSSL
-    version: 0.13
+    version: 18.0
 - name: install ndg-httpsclient
   pip:
     name: ndg-httpsclient
@@ -35,12 +35,17 @@
        force=yes
   with_items: '{{ icinga2_ubuntu_pkg_deps }}'
 
+- name: Get OS ubuntu lsb release
+  shell: lsb_release -c -s
+  register: lsb_release
+
 - name: Install Icinga2 on Debian OS family
-  apt: pkg={{ item.package }}
+  apt: pkg={{ item }}
        update_cache=yes
        install_recommends=no
        force=yes
-  with_items: '{{ icinga2_ubuntu_pkg }}'
+  with_items:
+    - "icinga2={{ icinga2_version }}.{{ lsb_release.stdout }}"
 
 - name: Start Icinga2
   service: name=icinga2

--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
@@ -6,6 +6,9 @@
   apt: name=icinga2-ido-mysql
        state=latest
 
+- name: Install libapache2-mod-php
+  apt: name=libapache2-mod-php
+
 - name: Create a IDO Database for Icinga2
   mysql_db:
     name: "{{ icinga2_db }}"
@@ -16,7 +19,7 @@
   register: icinga_ido_db
 
 - name: Create Icinga2 IDO Database User and configure Grants
-  mysql_user: 
+  mysql_user:
     name: "{{ icinga2_db_user }}"
     host: "%"
     password: "{{ icinga2_db_pass }}"
@@ -26,13 +29,13 @@
     login_user: "{{ db_root_username }}"
     login_password: "{{ db_root_password }}"
   # register: icinga_ido_db
-  # Removed this register because this always registers as changed and will 
-  # attempt to re-run "Import the IDO Schema on Icinga Web Database (only once)" 
-  # which will cause the play to fail. This will still get triggered off of DB 
+  # Removed this register because this always registers as changed and will
+  # attempt to re-run "Import the IDO Schema on Icinga Web Database (only once)"
+  # which will cause the play to fail. This will still get triggered off of DB
   # creation.
 
 - name: Import the IDO Schema on Icinga Web Database (only once)
-  mysql_db: 
+  mysql_db:
     name: "{{ icinga2_db }}"
     state: import
     target: "{{ icinga2_web_mysql_schema_debian }}"
@@ -64,7 +67,7 @@
   tags: icinga2-ansible-web2-ui-install
 
 - name: Create a Web Database for Icinga2
-  mysql_db: 
+  mysql_db:
     name: "{{ icinga2_web2_db }}"
     state: present
     login_host: "{{ db_host }}"
@@ -100,7 +103,7 @@
 
 - name: Add timezone to php.ini
   replace:
-    path: /etc/php5/apache2/php.ini
+    path: /etc/php/7.0/apache2/php.ini
     regexp: '^;date.timezone =.*'
     replace: 'date.timezone = America/Chicago'
 


### PR DESCRIPTION
With the new AMI based on Ubuntu Xenial we have to upgrade few packages otherwise they will not build.

@Workiva/sre 